### PR TITLE
bugfixes, and added crowding option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ add_executable(GRASSMIND3 ${SOURCES} ${HEADERS})
 target_include_directories(GRASSMIND3 PUBLIC include)
 
 #Create library target
-add_library(grassmind3 STATIC
+add_library(grassmind3lib STATIC
     src/utils/utils.cpp
     src/module_output/output.cpp
     src/module_input/input.cpp
@@ -93,6 +93,6 @@ add_library(grassmind3 STATIC
     src/module_interaction/interaction.cpp
     src/pythoninterface/pythoninterface.cpp
 )
-set_target_properties(grassmind3 PROPERTIES POSITION_INDEPENDENT_CODE ON)
-target_include_directories(grassmind3 PUBLIC include)
+set_target_properties(grassmind3lib PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(grassmind3lib PUBLIC include)
 

--- a/parameters/BioDT-generic/plant_traits__generic_v1.txt
+++ b/parameters/BioDT-generic/plant_traits__generic_v1.txt
@@ -282,7 +282,7 @@ h2H	-20000
 \unit:
 \description:waterpotential maximal uptake high Respiration (only required for BODIUM coupling)
 
-minLayerReductionFactorFromTopLayer	1
+crowdingCalculationFromPlantTopLayer	1
 \datatype:integer
 \unit:
 \description:use top layer for calculation and not fullest layer (only required for BODIUM coupling)

--- a/parameters/couplingProject/plant_traits__ambient_intensive_v1.txt
+++ b/parameters/couplingProject/plant_traits__ambient_intensive_v1.txt
@@ -132,7 +132,7 @@ plantShootRootRatio	3.41
 \unit:g(odm) g(odm)-1
 \description:shoot to root ratio (organic dry matter of biomass)
 
-plantRootDepthParamIntercept	0.60471778
+plantRootDepthParamIntercept	4.97561694
 \datatype:float-array
 \description:intercept of power-law relationship of shoot biomass with rooting depth
 

--- a/parameters/couplingProject/plant_traits__ambient_intensive_v1.txt
+++ b/parameters/couplingProject/plant_traits__ambient_intensive_v1.txt
@@ -282,7 +282,7 @@ h2H	-20000
 \unit:
 \description:waterpotential maximal uptake high Respiration (only required for BODIUM coupling)
 
-minLayerReductionFactorFromTopLayer	1
+crowdingCalculationFromPlantTopLayer	1
 \datatype:integer
 \unit:
 \description:use top layer for calculation and not fullest layer (only required for BODIUM coupling)

--- a/setup.py
+++ b/setup.py
@@ -24,12 +24,9 @@ include_dirs = [packageDir, sourceDir, numpy.get_include()]
 libDirs = [currentFolder, buildDir]
 
 if sys.platform == "win32":
-    libraries = ["Bodium", "winmm", "Advapi32", "Qt6Widgets", "Qt6Core", "Qt6Gui"]
-    extra_compile_args = ["/std:c++17", "/O2", "/Zc:__cplusplus"]
-    define_macros = [("NPY_NO_DEPRECATED_API", "NPY_1_7_API_VERSION")]
-
+    raise RuntimeError("Python binding not yet adapted for windows!")
 else:
-    libraries = ["grassmind3"]
+    libraries = ["grassmind3lib"]
     extra_compile_args = ["-O0", "-g", "-DCYTHON_TRACE=1"]
     define_macros = []
 
@@ -52,7 +49,7 @@ setup(
     name=packageName + "." + NAME,
     ext_modules=cythonize(
         extensions,
-        gdb_debug=True,  # 🔥 THIS IS CRITICAL
+        gdb_debug=True,
         compiler_directives={
             "linetrace": True,
             "binding": True,

--- a/src/module_growth/growth.cpp
+++ b/src/module_growth/growth.cpp
@@ -223,18 +223,15 @@ double GROWTH::calculateEffectOfAirTemperatureOnGPP(double dayTimeAirTemperature
     {
         reductionFactor = 0;
     }
-
-    if (dayTimeAirTemperature > -5 && dayTimeAirTemperature <= 2)
+    else if (dayTimeAirTemperature <= 2)
     {
         reductionFactor = (0.02857 * dayTimeAirTemperature + 0.142);
     }
-
-    if (dayTimeAirTemperature > 2 && dayTimeAirTemperature <= 10)
+    else if (dayTimeAirTemperature <= 10)
     {
         reductionFactor = (0.1 * dayTimeAirTemperature);
     }
-
-    if (dayTimeAirTemperature > 10)
+    else
     {
         reductionFactor = 1.0;
     }

--- a/src/module_init/init.cpp
+++ b/src/module_init/init.cpp
@@ -87,6 +87,7 @@ void INIT::resetVegetationProcessVariables(PARAMETER parameter, RECRUITMENT &rec
     community.totalLeafAreaIndexOfPlantsInCommunity = 0;
     community.greenleafAreaIndexOfPlantsInCommunity = 0;
     community.coveredAreaOfAllPlants = 0.0;
+    community.coveredAreaOfAllPlantsPerHeightLayer.assign(maximumHeightLayer + 1, 0.0);
     community.abovegroundBiomassOfAllPlants = 0.0;
     community.abovegroundLitterBiomass = 0.0;
 

--- a/src/module_input/input.cpp
+++ b/src/module_input/input.cpp
@@ -559,7 +559,7 @@ void INPUT::transferPlantTraitsParameterValueToModelParameter(PARAMETER &paramet
     /* parameter relevant for coupling */
     parameter.h2L = configParFloat["h2L"];
     parameter.h2H = configParFloat["h2H"];
-    parameter.minLayerReductionFactorFromTopLayer = configParInt["minLayerReductionFactorFromTopLayer"];
+    parameter.crowdingCalculationFromPlantTopLayer = configParInt["crowdingCalculationFromPlantTopLayer"];
     parameter.minLayerReductionFactorFromAverage = configParInt["minLayerReductionFactorFromAverage"];
     parameter.disableRunoff = configParBool["disableRunoff"];
 

--- a/src/module_mortality/mortality.cpp
+++ b/src/module_mortality/mortality.cpp
@@ -18,7 +18,7 @@ MORTALITY::~MORTALITY() {};
  *       vector. It performs checks to ensure that plant cohorts in the vector still have
  *       a minimum of one plant after applying the mortality processes.
  */
-void MORTALITY::doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL soil)
+void MORTALITY::doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL &soil)
 {
     for (int cohortIndex = 0; cohortIndex < community.totalNumberOfCohortsInCommunity; cohortIndex++)
     {
@@ -62,7 +62,7 @@ void MORTALITY::doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &co
 }
 
 /* Leaf and root senescence and litter fall */
-void MORTALITY::doSenescenceAndLitterFall(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL soil, int cohortIndex, int pft)
+void MORTALITY::doSenescenceAndLitterFall(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL &soil, int cohortIndex, int pft)
 {
     /// Leaf senescence
     double browningLeafBiomass = doLeafSenescence(community, parameter, growth, interaction, cohortIndex, pft);
@@ -78,7 +78,8 @@ void MORTALITY::doSenescenceAndLitterFall(UTILS utils, PARAMETER parameter, COMM
 double MORTALITY::doLeafSenescence(COMMUNITY &community, PARAMETER parameter, GROWTH growth, INTERACTION interaction, int cohortIndex, int pft)
 {
     double effectOfDayTimeTemperature = growth.calculateEffectOfAirTemperatureOnGPP(interaction.dayTimeAirTemperature);
-    double browningLeafBiomass = effectOfDayTimeTemperature * (community.allPlants.at(cohortIndex)->shootBiomassGreenLeaves / parameter.leafLifeSpan[pft]); // to be added: effect of community.allPlants.at(cohortIndex)->limitingFactorGppWater
+    double effectOfWaterLimitation = 1 - community.allPlants.at(cohortIndex)->limitingFactorGppWater;
+    double browningLeafBiomass = effectOfDayTimeTemperature * effectOfWaterLimitation * (community.allPlants.at(cohortIndex)->shootBiomassGreenLeaves / parameter.leafLifeSpan[pft]);
 
     community.allPlants.at(cohortIndex)->shootBiomassBrownLeaves += browningLeafBiomass;
     community.allPlants.at(cohortIndex)->shootBiomassGreenLeaves -= browningLeafBiomass;
@@ -93,7 +94,7 @@ double MORTALITY::doLeafSenescence(COMMUNITY &community, PARAMETER parameter, GR
     return (browningLeafBiomass);
 }
 
-void MORTALITY::doLeafLitterFall(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, SOIL soil, int cohortIndex, int pft)
+void MORTALITY::doLeafLitterFall(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, SOIL &soil, int cohortIndex, int pft)
 {
     if (community.allPlants.at(cohortIndex)->shootBiomassBrownLeaves > 0.0)
     {
@@ -147,7 +148,7 @@ void MORTALITY::updatePlantSize(UTILS utils, COMMUNITY &community, ALLOMETRY all
     community.allPlants.at(cohortIndex)->lai = community.allPlants.at(cohortIndex)->laiBrown + community.allPlants.at(cohortIndex)->laiGreen;
 }
 
-void MORTALITY::doRootSenescenceAndLitterFall(UTILS utils, COMMUNITY &community, PARAMETER parameter, SOIL soil, int cohortIndex, int pft)
+void MORTALITY::doRootSenescenceAndLitterFall(UTILS utils, COMMUNITY &community, PARAMETER parameter, SOIL &soil, int cohortIndex, int pft)
 {
     double dyingRootBiomass = community.allPlants.at(cohortIndex)->rootBiomass * (1.0 / parameter.rootLifeSpan[pft]);
 

--- a/src/module_mortality/mortality.cpp
+++ b/src/module_mortality/mortality.cpp
@@ -20,21 +20,19 @@ MORTALITY::~MORTALITY() {};
  */
 void MORTALITY::doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL &soil)
 {
+
     for (int cohortIndex = 0; cohortIndex < community.totalNumberOfCohortsInCommunity; cohortIndex++)
     {
         int pft = community.allPlants[cohortIndex]->pft;
 
         // 1. Leaf and root senescence and litter fall
         doSenescenceAndLitterFall(utils, parameter, community, allometry, growth, interaction, soil, cohortIndex, pft);
-
-        // 2. Update coveredAreaOfAllPlants to compare with simulationarea
-        if (community.allPlants.size() > 0)
-        {
-            for (int cohortindex = 0; cohortindex < community.allPlants.size(); cohortindex++)
-            {
-                community.coveredAreaOfAllPlants += community.allPlants[cohortindex]->coveredArea * parameter.plantShootOverlapFactors[community.allPlants[cohortindex]->pft] * community.allPlants[cohortindex]->amount;
-            }
-        }
+    }
+    // 2. Update coveredAreaOfAllPlants to compare with simulationarea
+    updateCoveredAreaOfAllPlants(parameter, community);
+    for (int cohortIndex = 0; cohortIndex < community.totalNumberOfCohortsInCommunity; cohortIndex++)
+    {
+        int pft = community.allPlants[cohortIndex]->pft;
 
         // 2. Crowding mortality
         if (parameter.crowdingMortalityActivated)
@@ -169,6 +167,32 @@ void MORTALITY::doNitrogenRelocation(UTILS utils, PARAMETER parameter, COMMUNITY
     community.allPlants[cohortIndex]->shootNitrogen -= relocatedNitrogen;
 }
 
+void MORTALITY::updateCoveredAreaOfAllPlants(PARAMETER parameter, COMMUNITY &community)
+    {
+        for (int cohortIndex = 0; cohortIndex < community.totalNumberOfCohortsInCommunity; cohortIndex++)
+        {
+            int pft = community.allPlants[cohortIndex]->pft;
+
+            if (community.allPlants.size() > 0)
+            {
+                for (int cohortindex = 0; cohortindex < community.allPlants.size(); cohortindex++)
+                {
+                    community.coveredAreaOfAllPlants += community.allPlants[cohortindex]->coveredArea * parameter.plantShootOverlapFactors[community.allPlants[cohortindex]->pft] * community.allPlants[cohortindex]->amount;
+                    if (parameter.crowdingCalculationFromPlantTopLayer)
+                    {   
+                        /// search for height layer up to which the plant cohort is reaching to
+                        /// Note: floor is used because first height layer 0-1 cm has index 0
+                        int topHeightLayerIndexOfPlant = (int)std::floor((community.allPlants.at(cohortindex)->height / heightLayerWidth));
+                        for (int layerindex = 0; layerindex <= topHeightLayerIndexOfPlant; layerindex++)
+                        {
+                            community.coveredAreaOfAllPlantsPerHeightLayer.at(layerindex) += community.allPlants[cohortindex]->coveredArea * parameter.plantShootOverlapFactors[community.allPlants[cohortindex]->pft] * community.allPlants[cohortindex]->amount;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
 /* Plant mortality due to thinning of the community */
 // * @cite Concept of crowding mortality is derived from the forest model FORMIND (www.formind.org)
 void MORTALITY::doPlantCrowding(PARAMETER parameter, UTILS utils, SOIL &soil, COMMUNITY &community, int cohortIndex, int pft)
@@ -178,8 +202,25 @@ void MORTALITY::doPlantCrowding(PARAMETER parameter, UTILS utils, SOIL &soil, CO
         if (community.coveredAreaOfAllPlants > SIMULATIONAREA)
         {
             /* amount of plants that shall die due to crowding */
-            double amountOfTooManyPlants = community.allPlants[cohortIndex]->amount * (1.0 - (SIMULATIONAREA / community.coveredAreaOfAllPlants));
-
+            double amountOfTooManyPlants;
+            if (parameter.crowdingCalculationFromPlantTopLayer)
+            {
+                /// search for height layer up to which the plant cohort is reaching to
+                /// Note: floor is used because first height layer 0-1 cm has index 0
+                int topHeightLayerIndexOfPlant = (int)std::floor((community.allPlants.at(cohortIndex)->height / heightLayerWidth));
+                if (community.coveredAreaOfAllPlantsPerHeightLayer.at(topHeightLayerIndexOfPlant) > SIMULATIONAREA)
+                {
+                    amountOfTooManyPlants = community.allPlants[cohortIndex]->amount * (1.0 - (SIMULATIONAREA / community.coveredAreaOfAllPlantsPerHeightLayer.at(topHeightLayerIndexOfPlant)));
+                }
+                else{
+                    amountOfTooManyPlants = 0.0;
+                }
+            } 
+            else 
+            {
+                amountOfTooManyPlants = community.allPlants[cohortIndex]->amount * (1.0 - (SIMULATIONAREA / community.coveredAreaOfAllPlants));
+            }
+            
             /* decide if either stochastic or deterministic mortality */
             if (parameter.stochasticSimulation)
             {

--- a/src/module_mortality/mortality.h
+++ b/src/module_mortality/mortality.h
@@ -21,13 +21,13 @@ public:
    MORTALITY();
    ~MORTALITY();
 
-   void doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL soil);
-   void doSenescenceAndLitterFall(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL soil, int cohortIndex, int pft);
+   void doPlantMortality(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL &soil);
+   void doSenescenceAndLitterFall(UTILS utils, PARAMETER parameter, COMMUNITY &community, ALLOMETRY allometry, GROWTH growth, INTERACTION interaction, SOIL &soil, int cohortIndex, int pft);
    double doLeafSenescence(COMMUNITY &community, PARAMETER parameter, GROWTH growth, INTERACTION interaction, int cohortIndex, int pft);
-   void doLeafLitterFall(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, SOIL soil, int cohortIndex, int pft);
+   void doLeafLitterFall(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, SOIL &soil, int cohortIndex, int pft);
    void updatePlantSize(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, int fractionLeavesFalling, int cohortIndex, int pft);
    void doNitrogenRelocation(UTILS utils, PARAMETER parameter, COMMUNITY &community, double browningLeafBiomass, int cohortIndex, int pft);
-   void doRootSenescenceAndLitterFall(UTILS utils, COMMUNITY &community, PARAMETER parameter, SOIL soil, int cohortIndex, int pft);
+   void doRootSenescenceAndLitterFall(UTILS utils, COMMUNITY &community, PARAMETER parameter, SOIL &soil, int cohortIndex, int pft);
    void doPlantCrowding(PARAMETER parameter, UTILS utils, SOIL &soil, COMMUNITY &community, int cohortIndex, int pft);
    void doBasicMortality(UTILS utils, PARAMETER parameter, SOIL &soil, COMMUNITY &community, int cohortIndex, int pft);
    double getPlantMortalityProbability(PARAMETER parameter, COMMUNITY community, int cohortIndex, int pft);

--- a/src/module_mortality/mortality.h
+++ b/src/module_mortality/mortality.h
@@ -28,6 +28,7 @@ public:
    void updatePlantSize(UTILS utils, COMMUNITY &community, ALLOMETRY allometry, PARAMETER parameter, int fractionLeavesFalling, int cohortIndex, int pft);
    void doNitrogenRelocation(UTILS utils, PARAMETER parameter, COMMUNITY &community, double browningLeafBiomass, int cohortIndex, int pft);
    void doRootSenescenceAndLitterFall(UTILS utils, COMMUNITY &community, PARAMETER parameter, SOIL &soil, int cohortIndex, int pft);
+   void updateCoveredAreaOfAllPlants(PARAMETER parameter, COMMUNITY &community);
    void doPlantCrowding(PARAMETER parameter, UTILS utils, SOIL &soil, COMMUNITY &community, int cohortIndex, int pft);
    void doBasicMortality(UTILS utils, PARAMETER parameter, SOIL &soil, COMMUNITY &community, int cohortIndex, int pft);
    double getPlantMortalityProbability(PARAMETER parameter, COMMUNITY community, int cohortIndex, int pft);

--- a/src/module_parameter/parameter.h
+++ b/src/module_parameter/parameter.h
@@ -70,7 +70,7 @@ public:
          "plantGppReductionBySoilWaterApproach", "lowerSoilWaterFractionForPlantGppReduction",
          "lowerSoilWaterContentForPlantGppReduction", "upperSoilWaterContentForPlantGppReduction",
          "plantResponseToTemperatureQ10Base", "plantResponseToTemperatureQ10Reference",
-         "h2L", "h2H", "minLayerReductionFactorFromTopLayer", "minLayerReductionFactorFromAverage", "disableRunoff"};
+         "h2L", "h2H", "crowdingCalculationFromPlantTopLayer", "minLayerReductionFactorFromAverage", "disableRunoff"};
 
     int pftCount;
     std::vector<double> maximumPlantHeight;
@@ -125,7 +125,7 @@ public:
     /* parameters relevant for coupling */
     double h2L;
     double h2H;
-    int minLayerReductionFactorFromTopLayer;
+    int crowdingCalculationFromPlantTopLayer;
     int minLayerReductionFactorFromAverage;
     int disableRunoff;
 

--- a/src/module_plant/community.h
+++ b/src/module_plant/community.h
@@ -42,6 +42,7 @@ public:
 
     // required for crowding, calculated in
     double coveredAreaOfAllPlants;
+    std::vector<double> coveredAreaOfAllPlantsPerHeightLayer;
 
     // required for carbon balance, calculated in
     double carbonRespirationOfAllPlants;

--- a/src/module_soil/soil.cpp
+++ b/src/module_soil/soil.cpp
@@ -545,7 +545,7 @@ void SOIL::calculateSoilWaterDemandPerPlant(UTILS utils, PARAMETER parameter, CO
             {
                 utils.handleError("Water-use-efficiency is zero. Please check the plant traits file!");
             }
-            community.totalSoilWaterDemand += community.allPlants.at(cohortindex)->soilWaterDemand;
+            community.totalSoilWaterDemand += community.allPlants.at(cohortindex)->amount *  community.allPlants.at(cohortindex)->soilWaterDemand;
 
             // demand per plant and community distributed uniformly among rooting layers
             for (int soilLayer = 0; soilLayer < rootingSoilLayers; soilLayer++)
@@ -1198,7 +1198,7 @@ void SOIL::calculateBodiumSoilNitrogenUptake(UTILS utils, PARAMETER parameter, C
 
     double meanRootDiameter = 5e-4; // m
     double meanSpecificRootLength =
-        120000 * 1000; // bodium config summeroats (m per kg) , coversion to m per ton
+        120000; // bodium config summeroats (m per kg)
 
     for (int cohortindex = 0; cohortindex < community.totalNumberOfCohortsInCommunity; cohortindex++)
     {
@@ -1251,16 +1251,16 @@ void SOIL::calculateBodiumSoilNitrogenUptake(UTILS utils, PARAMETER parameter, C
                     ratio_nh4 = (std::isnan(ratio_nh4)) ? 0 : ratio_nh4;
                     couplingInterface_plantNh4UptakePerSoilLayer[soilLayer] += community.allPlants.at(cohortindex)->amount * (new_nup * ratio_nh4);       // kg
                     couplingInterface_plantNo3UptakePerSoilLayer[soilLayer] += community.allPlants.at(cohortindex)->amount * (new_nup * (1 - ratio_nh4)); // kg
-                    community.allPlants.at(cohortindex)->soilNitrogenUptakePerSoilLayer[soilLayer] += new_nup / 1000;                                     // in tons
-                    community.allPlants.at(cohortindex)->totalSoilNitrogenUptake += new_nup / 1000;                                                       // tons
+                    community.allPlants.at(cohortindex)->soilNitrogenUptakePerSoilLayer[soilLayer] += new_nup * 1000;                                     // in g
+                    community.allPlants.at(cohortindex)->totalSoilNitrogenUptake += new_nup * 1000;                                                       // g
                 }
                 else
                 {
                     couplingInterface_plantNh4UptakePerSoilLayer[soilLayer] += community.allPlants.at(cohortindex)->amount * (water_up_n * nh4conc); // kg
                     couplingInterface_plantNo3UptakePerSoilLayer[soilLayer] += community.allPlants.at(cohortindex)->amount * (water_up_n * no3conc); // kg
                     community.allPlants.at(cohortindex)->soilNitrogenUptakePerSoilLayer[soilLayer] +=
-                        water_up_n * (nh4conc + no3conc) * 1 / 1000;                                                             // in tons
-                    community.allPlants.at(cohortindex)->totalSoilNitrogenUptake += water_up_n * (nh4conc + no3conc) * 1 / 1000; // tons
+                        water_up_n * (nh4conc + no3conc) * 1000;                                                             // in g
+                    community.allPlants.at(cohortindex)->totalSoilNitrogenUptake += water_up_n * (nh4conc + no3conc) * 1000; // g
                 }
             }
             n_conv = (n_conv > n_lim) ? n_lim : n_conv;

--- a/src/pythoninterface/pythoninterface.cpp
+++ b/src/pythoninterface/pythoninterface.cpp
@@ -34,7 +34,7 @@ void PYTHONINTERFACE::initializeSimulation(std::string path)
     /**
      * @brief Prepares output files for writing simulation results.
      */
-    output.prepareModelOutput(path, utils, parameter);
+    //output.prepareModelOutput(path, utils, parameter);
 
     /**
      * @brief Prints a summary of the simulation settings to the console.
@@ -88,6 +88,7 @@ void PYTHONINTERFACE::resetCouplingVariablesFluxes(PARAMETER &parameter, SOIL &s
 void PYTHONINTERFACE::setRandomNumberGeneratorSeed(unsigned int seed)
 {
     parameter.randomNumberGeneratorSeed = seed;
+    init.initRandomNumberGeneratorSeed(parameter, community);
     std::cout << "Seed of random number generator is changed to: " << std::to_string(seed) << std::endl
               << std::endl;
 }


### PR DESCRIPTION
- renaming lib in CMakeLists.txt to solve WIndows non-case-sensitivity problems
- adding crowding calculation "minLayerReductionFactorFromTopLayer" from grassmind2.0 but changing the name to "crowdingCalculationFromPlantTopLayer"
- bugfixes: missing plant amount in waterDemand calculation, unit conversion in bodiumUptake calculations, setting random number from python binding, passing reference to soil object not a copy (root litter now reaches soil)